### PR TITLE
feat: add ability to open using system default program

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ local default_config = {
   },
   misc = {
     trash_cmd = nil
+    system_open_cmd = nil
   }
 }
 ```
@@ -138,6 +139,8 @@ To use the functionalities provided by the `sfm` plugin, you can use the followi
 | c-space | clear_selections      | Clear all selections                                                                                       |
 |         | trash                 | Trash the current file or directory                                                                        |
 |         | trash_selections      | Trash all selected files or directories                                                                    |
+|         | system_open           | Open the selected file or directory using system default program                                           |
+|         | system_open_selections| Open all selected files or directories using system default program                                        |
 
 You can customize these key bindings by defining custom functions or action names in the `mappings` configuration option. For example, you can assign a custom function to the `t` key:
 

--- a/lua/sfm/actions.lua
+++ b/lua/sfm/actions.lua
@@ -594,6 +594,48 @@ function M.trash_selections()
   end)
 end
 
+--- open a file/directory using default system program
+function M.system_open()
+  local entry = M._renderer:get_current_entry()
+
+  if fs.system_open(entry.path, config.opts.misc.system_open_cmd) then
+    log.info(entry.path .. " has been opened using a system default program")
+  else
+    log.error("Opening of file " .. entry.name .. "using system default program failed due to an error.")
+  end
+end
+
+--- open selected files/directories using default system program
+function M.system_open_selections()
+  local selections = M._ctx:get_selections()
+  if vim.tbl_isempty(selections) then
+    log.warn "No files selected. Please select at least one file to proceed."
+
+    return
+  end
+
+  local paths = {}
+  for fpath, _ in pairs(selections) do
+    table.insert(paths, fpath)
+  end
+  paths = path.unify(paths)
+
+  local success_count = 0
+  for _, fpath in ipairs(paths) do
+    if fs.system_open(fpath, config.opts.misc.system_open_cmd) then
+      success_count = success_count + 1
+    end
+  end
+
+  log.info(
+    string.format(
+      "System opening process complete. %d files opened successfully, %d files failed.",
+      success_count,
+      vim.tbl_count(paths) - success_count
+    )
+  )
+end
+
 --- move/copy selected files/directories to a current opened entry or it's parent
 ---@param from_paths table
 ---@param to_dir string
@@ -903,6 +945,8 @@ function M.setup(explorer)
     delete_selections = M.delete_selections,
     trash = M.trash,
     trash_selections = M.trash_selections,
+    system_open = M.system_open,
+    system_open_selections = M.system_open_selections,
     copy = M.copy,
     copy_selections = M.copy_selections,
     move = M.move,

--- a/lua/sfm/config.lua
+++ b/lua/sfm/config.lua
@@ -129,7 +129,8 @@ local default_config = {
     },
   },
   misc = {
-    trash_cmd = nil
+    trash_cmd = nil,
+    system_open_cmd = nil
   }
 }
 

--- a/lua/sfm/utils/fs.lua
+++ b/lua/sfm/utils/fs.lua
@@ -225,4 +225,36 @@ function M.trash(source_path, trash_cmd)
   return true
 end
 
+--- system_open source_path using trash_cmd
+---@param source_path string
+---@param system_open_cmd table
+function M.system_open(source_path, system_open_cmd)
+  if not path.exists(source_path) then
+    return false
+  end
+
+  local exec_cmd = {}
+
+  if system_open_cmd then
+    if vim.fn.executable(system_open_cmd[1]) == 1 then
+      exec_cmd = system_open_cmd
+    else
+      return false
+    end
+  else
+    if vim.fn.executable('xdg-open') == 1 then
+      exec_cmd = { 'xdg-open' }
+    elseif vim.fn.executable('open') == 1 then
+      exec_cmd = { 'open' }
+    else
+      return false
+    end
+  end
+
+  -- FIXME: make this non-blocking
+  table.insert(exec_cmd, source_path)
+  vim.fn.system(exec_cmd)
+  return true
+end
+
 return M


### PR DESCRIPTION
this adds 2 new actions
`system_open`
`system_open_selections`

which opens files using the system default program (folders in file explorer, images in image viewer, pdfs in pdf viewer .. etc)
it uses the `xdg-open` utility on linux and `open` on mac (I believe the windows cmd is `start` but I'm not 100% sure)

since this PR executes external commands like in the trash actions, the next logical step would be to extract similar logic from both into some external command executing utility (and making it non-blocking)