### PR TITLE
feat: add selection_render_method (replaces render_selection_in_sign)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ local default_config = {
         col = 1 -- int or function
       }
     },
-    render_selection_in_sign = false
+    selection_render_method = "icon" -- render method of selected entries, can be `icon`, `sign`, `highlight`.
   },
   mappings = {
     custom_only = false,

--- a/lua/sfm.lua
+++ b/lua/sfm.lua
@@ -96,7 +96,7 @@ function M.setup(opts)
     sfm_explorer.ctx:clear_selections()
   end)
 
-  if config.opts.view.render_selection_in_sign then
+  if config.opts.view.selection_render_method == "sign" then
     selection_renderer.init_sign()
 
     sfm_explorer:subscribe(event.ExplorerRendered, function(payload)

--- a/lua/sfm/config.lua
+++ b/lua/sfm/config.lua
@@ -100,7 +100,7 @@ local default_config = {
         col = 1,
       },
     },
-    render_selection_in_sign = false,
+    selection_render_method = "icon",
   },
   mappings = {
     custom_only = false,

--- a/lua/sfm/renderer/init.lua
+++ b/lua/sfm/renderer/init.lua
@@ -41,7 +41,7 @@ function Renderer.new(ctx, view)
     func = icon_renderer.render_entry_icon,
     priority = 30,
   })
-  if not config.opts.view.render_selection_in_sign then
+  if config.opts.view.selection_render_method == "icon" then
     table.insert(self.renderers, {
       name = "selection",
       func = selection_renderer.render_selection,

--- a/lua/sfm/renderer/name_renderer.lua
+++ b/lua/sfm/renderer/name_renderer.lua
@@ -1,3 +1,7 @@
+local api = require "sfm.api"
+
+local config = require "sfm.config"
+
 local M = {}
 
 --- render name for the given entry
@@ -7,6 +11,9 @@ local M = {}
 function M.render_entry_name(entry)
   local name = entry.name
   local name_hl_group = entry.is_dir and "SFMFolderName" or "SFMFileName"
+  if config.opts.view.selection_render_method == "highlight" and api.context.is_selected(entry.path) then
+    name_hl_group = "SFMSelection"
+  end
 
   return {
     text = name,


### PR DESCRIPTION
Hey!
This replaces the config `render_selection_in_sign` with `selection_render_method` which can be one of `icon`, `sign` or the new method `highlight` and renders entry selection accordingly.