### PR TITLE
fix: use vim.notify title opt instead of a prefix

### DIFF
--- a/lua/sfm/utils/input.lua
+++ b/lua/sfm/utils/input.lua
@@ -1,3 +1,5 @@
+local log = require "sfm.utils.log"
+
 local M = {}
 
 function M.prompt(msg, default, completion, on_confirm)
@@ -7,7 +9,7 @@ function M.prompt(msg, default, completion, on_confirm)
 end
 
 function M.confirm(msg, on_yes, on_no, on_cancel)
-  vim.notify(msg)
+  log.info(msg)
   local choice = vim.fn.nr2char(vim.fn.getchar())
   if choice:match "^y" or choice:match "^Y" then
     on_yes()

--- a/lua/sfm/utils/log.lua
+++ b/lua/sfm/utils/log.lua
@@ -1,20 +1,22 @@
 local M = {}
 
+M.title = "SFM"
+
 function M.info(message)
   vim.schedule(function()
-    vim.notify("[sfm] " .. message, vim.log.levels.INFO)
+    vim.notify(message, vim.log.levels.INFO, { title = M.title })
   end)
 end
 
 function M.warn(message)
   vim.schedule(function()
-    vim.notify("[sfm] " .. message, vim.log.levels.WARN)
+    vim.notify(message, vim.log.levels.WARN, { title = M.title })
   end)
 end
 
 function M.error(message)
   vim.schedule(function()
-    vim.notify("[sfm] " .. message, vim.log.levels.ERROR)
+    vim.notify(message, vim.log.levels.ERROR, { title = M.title })
   end)
 end
 


### PR DESCRIPTION
a recent discovery of mine, vim.notify renderers (noice, nvim-notify) look for this to put a title, if the user is using none of them no title is shown like how god intended it to be ahahah

using the logger in `input` gives us titles there too
![image](https://github.com/dinhhuy258/sfm.nvim/assets/16624558/fd77fda9-df33-4a91-824e-be2eb427c728)
 