### PR TITLE
feat: make actions dynamically work with selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,18 +129,22 @@ To use the functionalities provided by the `sfm` plugin, you can use the followi
 | R       | reload                | Reload the explorer                                                                                        |
 | q       | close                 | Close the explorer window                                                                                  |
 | n       | create                | Create a new file/directory in the current folder                                                          |
-| c       | copy                  | Copy the current file or directory to a destination path specified by the user                             |
-| p       | copy_selections       | Copy all selected files or directories to the current folder                                               |
-| r       | move                  | Move/rename the current file or directory                                                                  |
-| x       | move_selections       | Move all selected files or directories to the current folder                                               |
-| dd      | delete                | Delete the current file or directory                                                                       |
-| ds      | delete_selections     | Delete all selected files or directories                                                                   |
+| c       | copy                  | Copy current/selected file/s directory/ies                                                                 |
+| r       | move                  | Move/Rename current/selected file/s directory/ies                                                          |
+| d       | delete                | Delete current/selected file/s directory/ies                                                               |
 | space   | toggle_selection      | Toggle the selection of the current file or directory                                                      |
 | c-space | clear_selections      | Clear all selections                                                                                       |
-|         | trash                 | Trash the current file or directory                                                                        |
-|         | trash_selections      | Trash all selected files or directories                                                                    |
-|         | system_open           | Open the selected file or directory using system default program                                           |
-|         | system_open_selections| Open all selected files or directories using system default program                                        |
+|         | trash                 | Trash current/selected file/s directory/ies                                                                |
+|         | system_open           | Open current/selected file/s directory/ies using system default program                                    |
+
+Below is a list of deprecated actions that should not be used anymore and might be removed anytime:
+| Action                |
+| --------------------- |
+| copy_selections       |
+| move_selections       |
+| delete_selections     |
+| trash_selections      |
+| system_open_selections|
 
 You can customize these key bindings by defining custom functions or action names in the `mappings` configuration option. For example, you can assign a custom function to the `t` key:
 

--- a/lua/sfm/actions.lua
+++ b/lua/sfm/actions.lua
@@ -434,8 +434,19 @@ function M.create()
   end)
 end
 
---- delete a file/directory
+--- delete open file/s directory/ies
 function M.delete()
+  local selections = M._ctx:get_selections()
+  local count = vim.tbl_count(selections)
+  if count > 1 then
+    M.delete_selections()
+  else
+    M.delete_single()
+  end
+end
+
+--- delete a single file/directory
+function M.delete_single()
   local entry = M._renderer:get_current_entry()
   input.confirm("Are you sure you want to delete file " .. entry.name .. "? (y/n)", function()
     -- on yes
@@ -515,8 +526,19 @@ function M.delete_selections()
   end)
 end
 
---- trash a file/directory
+--- trash open file/s directory/ies
 function M.trash()
+  local selections = M._ctx:get_selections()
+  local count = vim.tbl_count(selections)
+  if count > 1 then
+    M.trash_selections()
+  else
+    M.trash_single()
+  end
+end
+
+--- trash a single file/directory
+function M.trash_single()
   local entry = M._renderer:get_current_entry()
   input.confirm("Are you sure you want to trash file " .. entry.name .. "? (y/n)", function()
     -- on yes
@@ -596,8 +618,19 @@ function M.trash_selections()
   end)
 end
 
---- open a file/directory using default system program
+--- system open file/s directory/ies
 function M.system_open()
+  local selections = M._ctx:get_selections()
+  local count = vim.tbl_count(selections)
+  if count > 1 then
+    M.system_open_selections()
+  else
+    M.system_open_single()
+  end
+end
+
+--- open a single file/directory using default system program
+function M.system_open_single()
   local entry = M._renderer:get_current_entry()
 
   if fs.system_open(entry.path, config.opts.misc.system_open_cmd) then
@@ -712,8 +745,19 @@ local function _paste(from_paths, to_dir, action_fn, before_action_fn, on_action
   )
 end
 
---- move/rename a current file/directory
+--- move file/s directory/ies
 function M.move()
+  local selections = M._ctx:get_selections()
+  local count = vim.tbl_count(selections)
+  if count > 1 then
+    M.move_selections()
+  else
+    M.move_single()
+  end
+end
+
+--- move/rename a single current file/directory
+function M.move_single()
   local entry = M._renderer:get_current_entry()
   local from_path = entry.path
 
@@ -756,8 +800,19 @@ function M.move()
   end)
 end
 
---- copy file/directory
+--- copy file/s directory/ies
 function M.copy()
+  local selections = M._ctx:get_selections()
+  local count = vim.tbl_count(selections)
+  if count > 1 then
+    M.copy_selections()
+  else
+    M.copy_single()
+  end
+end
+
+--- copy a single file/directory
+function M.copy_single()
   local entry = M._renderer:get_current_entry()
   local from_path = entry.path
 
@@ -944,14 +999,19 @@ function M.setup(explorer)
     close = M.close,
     create = M.create,
     delete = M.delete,
+    delete_single = M.delete_single,
     delete_selections = M.delete_selections,
     trash = M.trash,
+    trash_single = M.trash_single,
     trash_selections = M.trash_selections,
     system_open = M.system_open,
+    system_open_single = M.system_open_single,
     system_open_selections = M.system_open_selections,
     copy = M.copy,
+    copy_single = M.copy_single,
     copy_selections = M.copy_selections,
     move = M.move,
+    move_single = M.move_single,
     move_selections = M.move_selections,
     toggle_selection = M.toggle_selection,
     clear_selections = M.clear_selections,

--- a/lua/sfm/actions.lua
+++ b/lua/sfm/actions.lua
@@ -439,7 +439,7 @@ function M.delete()
   local selections = M._ctx:get_selections()
   local count = vim.tbl_count(selections)
   if count > 1 then
-    M.delete_selections()
+    M._delete_selections()
   else
     M.delete_single()
   end
@@ -475,7 +475,7 @@ function M.delete_single()
 end
 
 --- delete selected files/directories
-function M.delete_selections()
+function M._delete_selections()
   local selections = M._ctx:get_selections()
   if vim.tbl_isempty(selections) then
     log.warn "No files selected. Please select at least one file to proceed."
@@ -531,7 +531,7 @@ function M.trash()
   local selections = M._ctx:get_selections()
   local count = vim.tbl_count(selections)
   if count > 1 then
-    M.trash_selections()
+    M._trash_selections()
   else
     M.trash_single()
   end
@@ -567,7 +567,7 @@ function M.trash_single()
 end
 
 --- trash selected files/directories
-function M.trash_selections()
+function M._trash_selections()
   local selections = M._ctx:get_selections()
   if vim.tbl_isempty(selections) then
     log.warn "No files selected. Please select at least one file to proceed."
@@ -623,7 +623,7 @@ function M.system_open()
   local selections = M._ctx:get_selections()
   local count = vim.tbl_count(selections)
   if count > 1 then
-    M.system_open_selections()
+    M._system_open_selections()
   else
     M.system_open_single()
   end
@@ -641,7 +641,7 @@ function M.system_open_single()
 end
 
 --- open selected files/directories using default system program
-function M.system_open_selections()
+function M._system_open_selections()
   local selections = M._ctx:get_selections()
   if vim.tbl_isempty(selections) then
     log.warn "No files selected. Please select at least one file to proceed."
@@ -750,7 +750,7 @@ function M.move()
   local selections = M._ctx:get_selections()
   local count = vim.tbl_count(selections)
   if count > 1 then
-    M.move_selections()
+    M._move_selections()
   else
     M.move_single()
   end
@@ -805,7 +805,7 @@ function M.copy()
   local selections = M._ctx:get_selections()
   local count = vim.tbl_count(selections)
   if count > 1 then
-    M.copy_selections()
+    M._copy_selections()
   else
     M.copy_single()
   end
@@ -850,7 +850,7 @@ function M.copy_single()
 end
 
 --- copy selected files/directories to a current opened entry or it's parent
-function M.copy_selections()
+function M._copy_selections()
   local selections = M._ctx:get_selections()
   if vim.tbl_isempty(selections) then
     log.warn "No files selected. Please select at least one file to proceed."
@@ -880,7 +880,7 @@ function M.copy_selections()
 end
 
 --- move selected files/directories to a current opened entry or it's parent
-function M.move_selections()
+function M._move_selections()
   local selections = M._ctx:get_selections()
   if vim.tbl_isempty(selections) then
     log.warn "No files selected. Please select at least one file to proceed."
@@ -975,6 +975,12 @@ function M.run(action)
   defined_action()
 end
 
+function M.deprecated(message)
+  return function()
+    log.warn(message)
+  end
+end
+
 --- setup actions
 ---@param explorer Explorer
 function M.setup(explorer)
@@ -999,22 +1005,17 @@ function M.setup(explorer)
     close = M.close,
     create = M.create,
     delete = M.delete,
-    delete_single = M.delete_single,
-    delete_selections = M.delete_selections,
     trash = M.trash,
-    trash_single = M.trash_single,
-    trash_selections = M.trash_selections,
     system_open = M.system_open,
-    system_open_single = M.system_open_single,
-    system_open_selections = M.system_open_selections,
     copy = M.copy,
-    copy_single = M.copy_single,
-    copy_selections = M.copy_selections,
     move = M.move,
-    move_single = M.move_single,
-    move_selections = M.move_selections,
     toggle_selection = M.toggle_selection,
     clear_selections = M.clear_selections,
+    delete_selections = M.deprecated(string.format("Deprecated action %s, use %s", "delete_selections", "delete")),
+    trash_selections = M.deprecated(string.format("Deprecated action %s, use %s", "trash_selections", "trash")),
+    system_open_selections = M.deprecated(string.format("Deprecated action %s, use %s", "system_open_selections", "system_open")),
+    copy_selections = M.deprecated(string.format("Deprecated action %s, use %s", "copy_selections", "copy")),
+    move_selections = M.deprecated(string.format("Deprecated action %s, use %s", "move_selections", "move")),
   }
 end
 

--- a/lua/sfm/actions.lua
+++ b/lua/sfm/actions.lua
@@ -436,9 +436,7 @@ end
 
 --- delete open file/s directory/ies
 function M.delete()
-  local selections = M._ctx:get_selections()
-  local count = vim.tbl_count(selections)
-  if count > 1 then
+  if vim.tbl_count(M._ctx:get_selections()) > 0 then
     M._delete_selections()
   else
     M._delete_current()
@@ -528,9 +526,7 @@ end
 
 --- trash open file/s directory/ies
 function M.trash()
-  local selections = M._ctx:get_selections()
-  local count = vim.tbl_count(selections)
-  if count > 1 then
+  if vim.tbl_count(M._ctx:get_selections()) > 0 then
     M._trash_selections()
   else
     M._trash_current()
@@ -620,9 +616,7 @@ end
 
 --- system open file/s directory/ies
 function M.system_open()
-  local selections = M._ctx:get_selections()
-  local count = vim.tbl_count(selections)
-  if count > 1 then
+  if vim.tbl_count(M._ctx:get_selections()) > 0 then
     M._system_open_selections()
   else
     M._system_open_current()
@@ -747,9 +741,7 @@ end
 
 --- move file/s directory/ies
 function M.move()
-  local selections = M._ctx:get_selections()
-  local count = vim.tbl_count(selections)
-  if count > 1 then
+  if vim.tbl_count(M._ctx:get_selections()) > 0 then
     M._move_selections()
   else
     M._move_current()
@@ -838,9 +830,7 @@ end
 
 --- copy file/s directory/ies
 function M.copy()
-  local selections = M._ctx:get_selections()
-  local count = vim.tbl_count(selections)
-  if count > 1 then
+  if vim.tbl_count(M._ctx:get_selections()) > 0 then
     M._copy_selections()
   else
     M._copy_current()

--- a/lua/sfm/config.lua
+++ b/lua/sfm/config.lua
@@ -60,8 +60,8 @@ local default_mappings = {
     action = "copy",
   },
   {
-    key = "r",
-    action = "move_selections",
+    key = "x",
+    action = "move",
   },
   {
     key = "<SPACE>",

--- a/lua/sfm/config.lua
+++ b/lua/sfm/config.lua
@@ -52,28 +52,16 @@ local default_mappings = {
     action = "create",
   },
   {
-    key = "dd",
+    key = "d",
     action = "delete",
-  },
-  {
-    key = "ds",
-    action = "delete_selections",
   },
   {
     key = "c",
     action = "copy",
   },
   {
-    key = "p",
-    action = "copy_selections",
-  },
-  {
-    key = "x",
-    action = "move_selections",
-  },
-  {
     key = "r",
-    action = "move",
+    action = "move_selections",
   },
   {
     key = "<SPACE>",


### PR DESCRIPTION
Hey, I've had this idea for a long time now, this PR makes the 5 actions that have a `_selections` variant (`copy`, `cut`, `delete`, `trash`, `system_open`) work as follows:

- if there is zero or one selection use the "single" action
- if there are 2 or more selections use the "_selections" actions

This PR of course aims to deprecated all `_selections` actions in the future, my plan is to merge them into a more unified logic for all actions that accept more than one entries in my next PR.

Also added a deprecation warning when the user tries to use the `x_selections` actions directing them to use just `x`