### PR TITLE
fix: use the job system instead of fn.system

### DIFF
--- a/lua/sfm/utils/fs.lua
+++ b/lua/sfm/utils/fs.lua
@@ -1,4 +1,5 @@
 local path = require "sfm.utils.path"
+local job = require "sfm.utils.job"
 
 local M = {}
 
@@ -227,10 +228,9 @@ function M.trash(source_path, trash_cmd)
     end
   end
 
-  -- FIXME: make this non-blocking
   table.insert(trash_cmd, source_path)
-  vim.fn.system(trash_cmd)
-  return true
+
+  return job.execute_cmd(trash_cmd, 1000) == 0
 end
 
 --- system_open source_path using trash_cmd
@@ -265,10 +265,8 @@ function M.system_open(source_path, system_open_cmd)
     end
   end
 
-  -- FIXME: make this non-blocking
   table.insert(system_open_cmd, source_path)
-  vim.fn.system(system_open_cmd)
-  return true
+  return job.execute_cmd(system_open_cmd, 1000) == 0
 end
 
 return M

--- a/lua/sfm/utils/job.lua
+++ b/lua/sfm/utils/job.lua
@@ -1,0 +1,20 @@
+local log = require "sfm.utils.log"
+
+local M = {}
+
+M.execute_cmd = function(cmd, timeout)
+  local job_id = vim.fn.jobstart(cmd)
+  exit_code = vim.fn.jobwait({ job_id }, timeout)[1]
+
+  if exit_code == -1 then
+    log.warn("Job " .. job_id .. " Timeout")
+  elseif exit_code == -2 then
+    log.warn("Job " .. job_id .. " Interrupted")
+  elseif exit_code == -3 then
+    log.warn("Job " .. job_id .. " Invalid")
+  end
+
+  return exit_code
+end
+
+return M


### PR DESCRIPTION
This is a follow up on my trash and system_open PRs which makes use of the internal job system for finer control, setting timeouts and properly reading exit codes.